### PR TITLE
Support SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [
         .iOS(.v8),
         .watchOS(.v3),
-        .macOS(.v10_9)
+        .macOS(.v10_10)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "KeychainAccess-xcframework",
+    platforms: [
+        .iOS(.v8),
+        .watchOS(.v3),
+        .macOS(.v10_9)
+    ],
+    products: [
+        .library(
+            name: "KeychainAccess",
+            targets: ["KeychainAccess"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "KeychainAccess",
+            url: "https://github.com/WW-Digital/ios-KeychainAccess/releases/download/4.2.1/KeychainAccess.xcframework.zip",
+            checksum: "2e1505dde90b669058dea6d8ece62d83e50fe51faeaa7f9dd21398a817061b86"
+        ),
+    ]
+)


### PR DESCRIPTION
Adds a Package.swift file to make the xcframework available via SPM.

Currently blocked due to the fact that Swift Package binary targets are downloaded without GitHub credentials.

See: https://developer.apple.com/forums/thread/665436

Todo:
- [ ] Decide if it's ok to make an xcframework repo public, as this seems to be the only solution.
- [ ] Modify fastlane lane to update the `Package.swift` file with the release URL and zip file checksum (via `swift package compute-checksum`).
- [ ] Modify fastlane lane to check the platforms/versions against the source repo.